### PR TITLE
fix: golangci-lint v2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,15 @@ jobs:
               - equal: ["1", << parameters.cgo >>]
               - equal: [*pg_default, << parameters.pgver >>]
           steps:
+            - run:
+                name: Ensure golangci-lint is up to date
+                command: |
+                  if golangci-lint version | fgrep -q 'version 2' ; then
+                    cd $(mktemp -d)
+                    wget https://github.com/golangci/golangci-lint/releases/download/v2.0.0/golangci-lint-2.0.0-linux-amd64.tar.gz
+                    tar -axf golangci-lint-2.0.0-linux-amd64.tar.gz
+                    sudo install -m 755 golangci-lint-2.0.0-linux-amd64/golangci-lint /usr/local/bin
+                  fi
             - restore_cache:
                 name: Restore golangci-lint cache
                 keys:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,7 @@ linters:
         - pattern: cobra.CheckErr
       exclude-godoc-examples: true
     lll:
+      # keep settings matching golines formatter
       line-length: 120
       tab-width: 2
     wrapcheck:
@@ -77,6 +78,7 @@ formatters:
   enable:
     - gofumpt
     - goimports
+    - golines
   settings:
     gofumpt:
       extra-rules: true
@@ -85,6 +87,10 @@ formatters:
       local-prefixes:
         - github.com/6RiverSystems
         - go.6river.tech
+    golines:
+      max-len: 120
+      # match editorconfig
+      tab-len: 2
   exclusions:
     generated: lax
     paths:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,72 +1,93 @@
+version: "2"
 run:
-  go: "1.23"
+  go: "1.24"
+linters:
+  enable:
+    - copyloopvar
+    - forbidigo
+    - intrange
+    - lll
+    - unparam
+    # this is useful, but it is a MONSTROUS yak shave, don't have time for doing
+    # this 100% for now
+    # - wrapcheck
+  settings:
+    forbidigo:
+      forbid:
+        - pattern: os.Exit
+        - pattern: cobra.CheckErr
+      exclude-godoc-examples: true
+    lll:
+      line-length: 120
+      tab-width: 2
+    wrapcheck:
+      ignore-sigs:
+        # need to repeat the defaults
+        - .Errorf(
+        - errors.New(
+        - errors.Unwrap(
+        - .Wrap(
+        - .Wrapf(
+        - .WithMessage(
+        - .WithMessagef(
+        - .WithStack(
+        # failures from this are huge bugs and not expected to happen IRL
+        - net/http.NewRequestWithContext(
+        # these OS errors self annotate the file related to the failure, and so
+        # are thus generally already detailed enough
+        - os.Stat(
+        - os.RemoveAll(
+        - os.MkdirAll(
+        - os.Open(
+        - os.OpenFile(
+        - os.ReadDir(
+        # aggregate collapse
+        - .ErrorOrNil()
+        - multierror.Append(
+        # these just return context.Context.Err()
+        - channels.SendOrErr
+        # self-annotates
+        - config.GetConfig(
+      ignore-package-globs:
+        # context errors are generally just propagated and something else has the
+        # real error
+        - context
+        # errgroup.Wait returns something that should already be wrapped
+        - golang.org/x/sync/errgroup
+      ignore-interface-regexps:
+        # context errors are generally just propagated and something else has the
+        # real error
+        - context.Context
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
   uniq-by-line: false
-linters:
+formatters:
   enable:
-    - forbidigo
     - gofumpt
     - goimports
-    - unparam
-    - lll
-    - copyloopvar
-    - intrange
-
-    # this is useful, but it is a MONSTROUS yak shave, don't have time for doing
-    # this 100% for now
-    # - wrapcheck
-
-linters-settings:
-  forbidigo:
-    exclude-godoc-examples: true
-    forbid:
-      - "os.Exit"
-      - "cobra.CheckErr"
-  gofumpt:
-    extra-rules: true
-  goimports:
-    # keep in sync with magefile
-    local-prefixes: github.com/6RiverSystems,go.6river.tech
-  lll:
-    line-length: 120
-    tab-width: 2
-  wrapcheck:
-    ignorePackageGlobs:
-      # context errors are generally just propagated and something else has the
-      # real error
-      - "context"
-      # errgroup.Wait returns something that should already be wrapped
-      - "golang.org/x/sync/errgroup"
-    ignoreInterfaceRegexps:
-      # context errors are generally just propagated and something else has the
-      # real error
-      - "context.Context"
-    ignoreSigs:
-      # need to repeat the defaults
-      - ".Errorf("
-      - "errors.New("
-      - "errors.Unwrap("
-      - ".Wrap("
-      - ".Wrapf("
-      - ".WithMessage("
-      - ".WithMessagef("
-      - ".WithStack("
-      # failures from this are huge bugs and not expected to happen IRL
-      - "net/http.NewRequestWithContext("
-      # these OS errors self annotate the file related to the failure, and so
-      # are thus generally already detailed enough
-      - "os.Stat("
-      - "os.RemoveAll("
-      - "os.MkdirAll("
-      - "os.Open("
-      - "os.OpenFile("
-      - "os.ReadDir("
-      # aggregate collapse
-      - ".ErrorOrNil()"
-      - "multierror.Append("
-      # these just return context.Context.Err()
-      - "channels.SendOrErr"
-      # self-annotates
-      - "config.GetConfig("
+  settings:
+    gofumpt:
+      extra-rules: true
+    goimports:
+      # keep in sync with magefile
+      local-prefixes:
+        - github.com/6RiverSystems
+        - go.6river.tech
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/actions/action.go
+++ b/actions/action.go
@@ -107,7 +107,7 @@ func (at *actionTimer) Failed() {
 }
 
 func (at *actionTimer) Ended() {
-	if at.end == (time.Time{}) {
+	if at.end.IsZero() {
 		at.end = time.Now()
 	}
 }
@@ -116,7 +116,7 @@ func (at *actionTimer) ReportRollback() {
 	if at.reported {
 		return
 	}
-	if at.end == (time.Time{}) {
+	if at.end.IsZero() {
 		at.end = time.Now()
 	}
 	outcome := outcomeFailure
@@ -134,7 +134,7 @@ func (at *actionTimer) ReportCommit() {
 	if at.reported {
 		return
 	}
-	if at.end == (time.Time{}) {
+	if at.end.IsZero() {
 		at.end = time.Now()
 	}
 	outcome := outcomeFailure

--- a/actions/create-subscription.go
+++ b/actions/create-subscription.go
@@ -68,7 +68,7 @@ func NewCreateSubscription(params CreateSubscriptionParams) *CreateSubscription 
 		panic(errors.New("messageTTL must be > 0"))
 	}
 	if params.MaxDeliveryAttempts < 0 {
-		panic(errors.New("MaxDeliveryAttempts must be >= 0"))
+		panic(errors.New("maxDeliveryAttempts must be >= 0"))
 	}
 	if (params.MaxDeliveryAttempts != 0) != (params.DeadLetterTopic != "") {
 		panic(errors.New("must set both or neither of MaxDeliveryAttempts and DeadLetterTopic"))

--- a/actions/create-topic.go
+++ b/actions/create-topic.go
@@ -44,7 +44,7 @@ var _ Action[CreateTopicParams, createTopicResults] = (*CreateTopic)(nil)
 
 func NewCreateTopic(params CreateTopicParams) *CreateTopic {
 	if params.Name == "" {
-		panic(errors.New("Topic must have a non-empty name"))
+		panic(errors.New("topic must have a non-empty name"))
 	}
 	return &CreateTopic{
 		actionBase[CreateTopicParams, createTopicResults]{

--- a/actions/dead-letter-deliveries.go
+++ b/actions/dead-letter-deliveries.go
@@ -45,7 +45,7 @@ type DeadLetterDeliveries struct {
 
 func NewDeadLetterDeliveries(params DeadLetterDeliveriesParams) *DeadLetterDeliveries {
 	if params.MaxDeliveries < 1 {
-		panic(errors.New("MaxDeliveries must be > 0"))
+		panic(errors.New("maxDeliveries must be > 0"))
 	}
 	return &DeadLetterDeliveries{
 		actionBase[DeadLetterDeliveriesParams, DeadLetterDeliveriesResults]{

--- a/actions/errors.go
+++ b/actions/errors.go
@@ -25,9 +25,9 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 )
 
-var ErrExists = errors.New("Already exists")
+var ErrExists = errors.New("already exists")
 
-var ErrNotFound = errors.New("Not found")
+var ErrNotFound = errors.New("not found")
 
 func isSqlDuplicateKeyError(err error) bool {
 	var pgErr *pgconn.PgError

--- a/actions/get-subscription-messages.go
+++ b/actions/get-subscription-messages.go
@@ -75,17 +75,17 @@ var _ Action[GetSubscriptionMessagesParams, getSubscriptionMessagesResults] = (*
 
 func NewGetSubscriptionMessages(params GetSubscriptionMessagesParams) *GetSubscriptionMessages {
 	if params.MaxMessages < 1 {
-		panic(errors.New("MaxMessages must be > 0"))
+		panic(errors.New("maxMessages must be > 0"))
 	}
 	if params.MaxBytes < 1 {
-		panic(errors.New("MaxBytes must be > 0"))
+		panic(errors.New("maxBytes must be > 0"))
 	}
 	if params.MaxWait < 0 {
 		// we allow 0 here as "use the default"
-		panic(errors.New("MaxWait must be >= 0"))
+		panic(errors.New("maxWait must be >= 0"))
 	}
 	if params.Name == "" && params.ID == nil {
-		panic(errors.New("Must provide Name or ID"))
+		panic(errors.New("must provide Name or ID"))
 	}
 	return &GetSubscriptionMessages{
 		actionBase[GetSubscriptionMessagesParams, getSubscriptionMessagesResults]{

--- a/actions/notify.go
+++ b/actions/notify.go
@@ -354,7 +354,7 @@ func CancelPublishAwaiter(subID uuid.UUID, c PublishNotifier) {
 }
 
 // this has to return a two-way channel so that it can be passed to cancelSubModifiedAwaiter
-func SubModifiedAwaiter(subID uuid.UUID, subName string) SubModifiedNotifier { // nolint:deadcode,unused
+func SubModifiedAwaiter(subID uuid.UUID, subName string) SubModifiedNotifier {
 	c := make(chan struct{})
 	mk := modifyKey{subID, subName}
 	nmu.Lock()
@@ -373,7 +373,7 @@ func CancelSubModifiedAwaiter(
 	subID uuid.UUID,
 	subName string,
 	c SubModifiedNotifier,
-) { // nolint:deadcode,unused
+) {
 	if c == nil {
 		return
 	}

--- a/actions/prune-common.go
+++ b/actions/prune-common.go
@@ -33,10 +33,10 @@ type PruneCommonParams struct {
 
 func (p *PruneCommonParams) Validate() error {
 	if p.MinAge < 0 {
-		return errors.New("MinAge must be >= 0")
+		return errors.New("minAge must be >= 0")
 	}
 	if p.MaxDelete <= 0 {
-		return errors.New("MaxDelete must be > 0")
+		return errors.New("maxDelete must be > 0")
 	}
 
 	return nil

--- a/actions/publish-message.go
+++ b/actions/publish-message.go
@@ -52,7 +52,7 @@ var _ Action[PublishMessageParams, publishMessageResults] = (*PublishMessage)(ni
 
 func NewPublishMessage(params PublishMessageParams) *PublishMessage {
 	if params.TopicName == "" && params.TopicID == nil {
-		panic(errors.New("Must provide Name or ID"))
+		panic(errors.New("must provide Name or ID"))
 	}
 	return &PublishMessage{
 		actionBase[PublishMessageParams, publishMessageResults]{

--- a/actions/seek-subscription-to-time.go
+++ b/actions/seek-subscription-to-time.go
@@ -52,10 +52,10 @@ var _ Action[SeekSubscriptionToTimeParams, seekSubscriptionToTimeResults] = (*Se
 
 func NewSeekSubscriptionToTime(params SeekSubscriptionToTimeParams) *SeekSubscriptionToTime {
 	if params.Name == "" && params.ID == nil {
-		panic(errors.New("Must provide Name or ID"))
+		panic(errors.New("must provide Name or ID"))
 	}
-	if params.Time.IsZero() || (params.Time == time.Time{}) {
-		panic(errors.New("Target time must be specified as a non-zero value"))
+	if params.Time.IsZero() {
+		panic(errors.New("target time must be specified as a non-zero value"))
 	}
 	// FUTURE: do we want to bound how far in the future or past the target can be?
 	return &SeekSubscriptionToTime{

--- a/cmd/mmmbbb/main.go
+++ b/cmd/mmmbbb/main.go
@@ -54,7 +54,6 @@ import (
 	"go.6river.tech/mmmbbb/oas"
 	"go.6river.tech/mmmbbb/server"
 	"go.6river.tech/mmmbbb/services"
-	_ "go.6river.tech/mmmbbb/services"
 	"go.6river.tech/mmmbbb/version"
 )
 

--- a/controllers/action-handlers.go
+++ b/controllers/action-handlers.go
@@ -30,7 +30,7 @@ import (
 	"go.6river.tech/mmmbbb/ent"
 )
 
-// nolint:unused,deadcode // want to save this for future work
+// nolint:unused // want to save this for future work
 func handleActionError(c *gin.Context, err error) bool {
 	switch {
 	case errors.Is(err, actions.ErrNotFound):

--- a/controllers/fault-injector.go
+++ b/controllers/fault-injector.go
@@ -145,7 +145,7 @@ func errorFactory(errorType oas.ErrorType) func(faults.Description, faults.Param
 	var err error
 	err, ok := errorMap[errorType]
 	if !ok {
-		panic(fmt.Errorf("Unsupported error type '%s'", errorType))
+		panic(fmt.Errorf("unsupported error type '%s'", errorType))
 	}
 
 	// this relies on places checking for injections using errors.Is / errors.As
@@ -160,8 +160,8 @@ func errorFactory(errorType oas.ErrorType) func(faults.Description, faults.Param
 			err = ent.NewNotFoundError(label)
 		}
 		if len(d.Parameters) == 0 {
-			return fmt.Errorf("Injected fault matched %s(): %w", d.Operation, err)
+			return fmt.Errorf("injected fault matched %s(): %w", d.Operation, err)
 		}
-		return fmt.Errorf("Injected fault matched %s(%v): %w", d.Operation, d.Parameters, err)
+		return fmt.Errorf("injected fault matched %s(%v): %w", d.Operation, d.Parameters, err)
 	}
 }

--- a/db/conn-config.go
+++ b/db/conn-config.go
@@ -140,7 +140,7 @@ func ParseDefault() (driverName, dialectName, dsn string, err error) {
 		driverName = "pgx"
 		dialectName = PostgresDialect
 	} else {
-		return "", "", dsn, fmt.Errorf("Unrecognized db url '%s'", dsn)
+		return "", "", dsn, fmt.Errorf("unrecognized db url '%s'", dsn)
 	}
 	return
 }
@@ -171,7 +171,7 @@ func Open(driverName, dialectName, dsn string) (db *sql.DB, err error) {
 	} else {
 		db, err = sql.Open(driverName, dsn)
 		if err != nil {
-			err = fmt.Errorf("Failed to open default DB connection: %w", err)
+			err = fmt.Errorf("failed to open default DB connection: %w", err)
 		}
 	}
 
@@ -272,6 +272,6 @@ func TryCreateDB(ctx context.Context, driverName, dialect, dsn, createVia string
 		// TODO: detect "already exists" and report that as success (e.g. multiple instances racing to create)
 		return err
 	} else {
-		return errors.New("Don't know how to create this kind of db")
+		return errors.New("don't know how to create this kind of db")
 	}
 }

--- a/db/migrate.go
+++ b/db/migrate.go
@@ -58,7 +58,7 @@ func Up(
 		defer sql.Close()
 	}
 	if err != nil {
-		return fmt.Errorf("Failed to connect to DB for Up migration: %w", err)
+		return fmt.Errorf("failed to connect to DB for Up migration: %w", err)
 	}
 
 	if !migrator.HasMigrations() || dialectName == SqliteDialect {
@@ -66,11 +66,11 @@ func Up(
 		case *ent.Client:
 			err := MigrateUpEnt(ctx, mdb.Schema)
 			if err != nil {
-				return fmt.Errorf("Failed Up migration via ent for %s: %w", dialectName, err)
+				return fmt.Errorf("failed Up migration via ent for %s: %w", dialectName, err)
 			}
 			return nil
 		default:
-			return fmt.Errorf("Unrecognized migrateVia for %s: %T", dialectName, migrateVia)
+			return fmt.Errorf("unrecognized migrateVia for %s: %T", dialectName, migrateVia)
 		}
 	}
 
@@ -79,7 +79,7 @@ func Up(
 		migrator = migrator.WithDialect(&migrate.PgxDialect{})
 	default:
 		// TODO: if we had a dialect registry could make this generic
-		return fmt.Errorf("Unrecognized dialect '%s'", dialectName)
+		return fmt.Errorf("unrecognized dialect '%s'", dialectName)
 	}
 
 	// default fallthrough assumes we've initialized migrator with a dialect

--- a/db/postgres/quote.go
+++ b/db/postgres/quote.go
@@ -28,13 +28,13 @@ import (
 // https://github.com/jackc/pgx/blob/master/conn.go#L341 and
 // https://github.com/jackc/pgx/issues/202
 func QuoteIdentifier(s string) string {
-	return `"` + strings.Replace(s, `"`, `""`, -1) + `"`
+	return `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
 }
 
 // copy-pasta from pgx internals, see
 // https://github.com/jackc/pgx/blob/master/internal/sanitize/sanitize.go
 func QuoteString(str string) string {
-	return "'" + strings.Replace(str, "'", "''", -1) + "'"
+	return "'" + strings.ReplaceAll(str, "'", "''") + "'"
 }
 
 // copy-pasta from pgx internals, see

--- a/ent/client-addons.go
+++ b/ent/client-addons.go
@@ -106,11 +106,11 @@ func (c *Client) DB() *sql.DB {
 func DriverDB(driver dialect.Driver) *sql.DB {
 	switch d := driver.(type) {
 	case *entsql.Driver:
-		return d.Conn.ExecQuerier.(*sql.DB)
+		return d.ExecQuerier.(*sql.DB)
 	case *dialect.DebugDriver:
 		return DriverDB(d.Driver)
 	default:
-		panic(fmt.Errorf("Unable to find DB from %T", driver))
+		panic(fmt.Errorf("unable to find DB from %T", driver))
 	}
 }
 
@@ -127,7 +127,7 @@ func (tx *Tx) DBTx() *sql.Tx {
 		case *dialect.DebugTx:
 			etx = ttx.Tx
 		default:
-			panic(fmt.Errorf("Unrecognized dialect.Tx type %T", etx))
+			panic(fmt.Errorf("unrecognized dialect.Tx type %T", etx))
 		}
 	}
 }

--- a/filter/as-filter.go
+++ b/filter/as-filter.go
@@ -163,6 +163,9 @@ func formatAttrName(name string) string {
 	isIdent := true
 	for i, ch := range name {
 		// stolen from scanner.Scanner.isIdentRune
+		// (QF1001): applying De Morgan's law here just makes it more confusing, and
+		// diverges from the code whence it is copied
+		//nolint:staticcheck
 		if !(ch == '_' || unicode.IsLetter(ch) || unicode.IsDigit(ch) && i > 0) {
 			isIdent = false
 			break

--- a/filter/evaluate_test.go
+++ b/filter/evaluate_test.go
@@ -177,6 +177,7 @@ func TestEvaluateComplex(t *testing.T) {
 		{
 			"NOT (a OR b) AND c",
 			"NOT (attributes:a OR attributes:b) AND attributes:c",
+			//nolint:staticcheck // QF1001: keep this logic identical to what's being parsed
 			func(a, b, c bool) bool { return !(a || b) && c },
 		},
 	}

--- a/filter/grammar.go
+++ b/filter/grammar.go
@@ -23,14 +23,14 @@ type Filter = Condition
 
 type Condition struct {
 	Term *Term   `parser:"@@"              json:",omitempty"`
-	And  []*Term `parser:"( (\"AND\" @@ )+"  json:",omitempty"`
-	Or   []*Term `parser:"| (\"OR\" @@)+ )?" json:",omitempty"`
+	And  []*Term `parser:"( ("AND" @@ )+"  json:",omitempty"`
+	Or   []*Term `parser:"| ("OR" @@)+ )?" json:",omitempty"`
 }
 
 type Term struct {
-	Not   bool             `parser:"@(\"NOT\"|\"-\")?"`
+	Not   bool             `parser:"@("NOT"|"-")?"`
 	Basic *BasicExpression `parser:"( @@"           json:",omitempty"`
-	Sub   *Condition       `parser:"| \"(\" @@ \")\" )" json:",omitempty"`
+	Sub   *Condition       `parser:"| "(" @@ ")" )" json:",omitempty"`
 }
 
 type BasicExpression struct {
@@ -40,19 +40,19 @@ type BasicExpression struct {
 }
 
 type HasAttribute struct {
-	Name string `parser:"\"attributes\" \":\" @(Ident|String)"`
+	Name string `parser:""attributes" ":" @(Ident|String)"`
 }
 
 type HasAttributeValue struct {
-	Name  string            `parser:"\"attributes\" \".\" @(Ident|String)"`
-	Op    AttributeOperator `parser:"@(\"=\" | \"!\" \"=\")"`
+	Name  string            `parser:""attributes" "." @(Ident|String)"`
+	Op    AttributeOperator `parser:"@("=" | "!" "=")"`
 	Value string            `parser:"@String"`
 }
 
 type HasAttributePredicate struct {
-	Predicate AttributePredicate `parser:"@(\"hasPrefix\")\"(\""`
-	Name      string             `parser:"\"attributes\" \".\" @(Ident|String) \",\""`
-	Value     string             `parser:"@String \")\""`
+	Predicate AttributePredicate `parser:"@("hasPrefix")"(""`
+	Name      string             `parser:""attributes" "." @(Ident|String) ",""`
+	Value     string             `parser:"@String ")""`
 }
 
 type BooleanOperator string

--- a/grpc/server.go
+++ b/grpc/server.go
@@ -209,7 +209,7 @@ func (s *grpcServer) Start(ctx context.Context, ready chan<- struct{}) error {
 	if err != nil {
 		s.logger.Error().Err(err).Msg("Failed to open gRPC listen socket")
 
-		return fmt.Errorf("Failed to open listen port for grpc server: %w", err)
+		return fmt.Errorf("failed to open listen port for grpc server: %w", err)
 	}
 
 	// ask the server to stop when the context is canceled

--- a/internal/sqltypes/interval.go
+++ b/internal/sqltypes/interval.go
@@ -76,7 +76,7 @@ func (i *Interval) Scan(src interface{}) error {
 		// place
 		*i = 0
 	default:
-		return fmt.Errorf("Unsupported scan type: %T", src)
+		return fmt.Errorf("unsupported scan type: %T", src)
 	}
 	return nil
 }
@@ -115,7 +115,7 @@ func ParsePostgreSQLInterval(s string) (result time.Duration, err error) {
 		// try to parse in Go format, happens with sqlite
 		result, err = time.ParseDuration(s)
 		if err != nil {
-			err = errors.New("Unrecognized interval format")
+			err = errors.New("unrecognized interval format")
 		}
 		return
 	}
@@ -144,7 +144,7 @@ func ParsePostgreSQLInterval(s string) (result time.Duration, err error) {
 		// PG cannot store more than microsecond resolution, but we can at least
 		// tolerate up to what Go can represent on input
 		if len(subsecs) > 9 {
-			err = errors.New("Cannot parse beyond nanosecond resolution")
+			err = errors.New("cannot parse beyond nanosecond resolution")
 			return
 		}
 		// len(subsecs) is in the range [1..9], so we know that

--- a/migrate/load.go
+++ b/migrate/load.go
@@ -40,7 +40,7 @@ func LoadFS(
 
 		m := nameRegex.FindStringSubmatch(fn)
 		if m == nil {
-			return fmt.Errorf("Entry '%s' does not look like a migration", fn)
+			return fmt.Errorf("entry '%s' does not look like a migration", fn)
 		}
 		name, direction := m[1], m[2]
 		// for compatibility with db-migrate, where things are always scope/name,
@@ -62,12 +62,12 @@ func LoadFS(
 		}
 		if direction == "up" {
 			if e.up != nil {
-				return fmt.Errorf("Multiple up entries for '%s'", name)
+				return fmt.Errorf("multiple up entries for '%s'", name)
 			}
 			e.up = content
 		} else {
 			if e.down != nil {
-				return fmt.Errorf("Multiple down entries for '%s'", name)
+				return fmt.Errorf("multiple down entries for '%s'", name)
 			}
 			e.down = content
 		}

--- a/migrate/migration.go
+++ b/migrate/migration.go
@@ -101,7 +101,7 @@ func (m *SQLMigration) run(ctx context.Context, tx *sqlx.Tx, direction Direction
 	// this is meant to catch "no going back" migrations where once you "up",
 	// there is no (safe) way to go back down again.
 	if contents == "" {
-		return fmt.Errorf("No script to %s migration %s", direction, m.name)
+		return fmt.Errorf("no script to %s migration %s", direction, m.name)
 	}
 
 	_, err = tx.ExecContext(ctx, contents)

--- a/migrate/migrator.go
+++ b/migrate/migrator.go
@@ -133,19 +133,19 @@ func (m *Migrator) run(
 	}
 
 	if err := m.dialect.EnsureMigrationsTable(ctx, db, m.config); err != nil {
-		return fmt.Errorf("Failed ensuring migrations state table exists: %w", err)
+		return fmt.Errorf("failed ensuring migrations state table exists: %w", err)
 	}
 
 	states, err := m.loadStates(ctx, db)
 	if err != nil {
-		return fmt.Errorf("Failed to load migration states: %w", err)
+		return fmt.Errorf("failed to load migration states: %w", err)
 	}
 
 	todo := m.toRun(direction, states)
 
 	for _, mm := range todo {
 		if err = m.runOne(ctx, db, mm, direction); err != nil {
-			return fmt.Errorf("Failed to run migration %s: %w", mm.Name(), err)
+			return fmt.Errorf("failed to run migration %s: %w", mm.Name(), err)
 		}
 	}
 

--- a/migrate/pgx.go
+++ b/migrate/pgx.go
@@ -48,7 +48,7 @@ func (p *PgxDialect) DefaultConfig() *Config {
 
 func (p *PgxDialect) Verify(db *sqlx.DB) error {
 	if _, ok := db.Driver().(*stdlib.Driver); !ok {
-		return fmt.Errorf("Cannot use Pgx dialect without pgx driver")
+		return fmt.Errorf("cannot use Pgx dialect without pgx driver")
 	}
 	return nil
 }

--- a/server/router.go
+++ b/server/router.go
@@ -49,7 +49,7 @@ func NewEngine() *gin.Engine {
 			// TODO: actually probably want debug mode here too?
 			gin.SetMode(gin.TestMode)
 		default:
-			panic(fmt.Errorf("Unrecognized NODE_ENV value: '%s'", os.Getenv("NODE_ENV")))
+			panic(fmt.Errorf("unrecognized NODE_ENV value: '%s'", os.Getenv("NODE_ENV")))
 		}
 	}
 

--- a/services/grpc-compat_test.go
+++ b/services/grpc-compat_test.go
@@ -476,19 +476,20 @@ func TestGrpcCompat(t *testing.T) {
 						}
 						assert.Equal(t, strconv.Itoa(int(expected)), string(m.Data),
 							"should get expected message (in order)")
-						if counter == 1 {
+						switch counter {
+						case 1:
 							// go fast
 							defer m.Ack()
-						} else if counter == 2 {
+						case 2:
 							// delay and nack
 							defer m.Nack()
 							time.Sleep(pullTimeScale)
-						} else if counter == 3 {
+						case 3:
 							// delay and ack and done
 							defer m.Ack()
 							time.Sleep(pullTimeScale * 3 / 2)
 							cancel()
-						} else {
+						default:
 							assert.LessOrEqual(t, expected, int32(3))
 						}
 						// t.Logf("done with %q at %d", m.ID, counter)
@@ -544,19 +545,20 @@ func TestGrpcCompat(t *testing.T) {
 							expected = 2
 						}
 						assert.Equal(t, ([]byte)(strconv.Itoa(int(expected))), m.Data)
-						if counter == 1 {
+						switch counter {
+						case 1:
 							// go fast
 							defer m.Ack()
-						} else if counter == 2 {
+						case 2:
 							// delay and nack
 							defer m.Nack()
 							time.Sleep(pullTimeScale)
-						} else if counter == 3 {
+						case 3:
 							// delay and ack and done
 							defer m.Ack()
 							time.Sleep(pullTimeScale * 3 / 2)
 							cancel()
-						} else {
+						default:
 							assert.LessOrEqual(t, expected, int32(3))
 						}
 					})
@@ -655,19 +657,20 @@ func TestGrpcCompat(t *testing.T) {
 						decoded, err := base64.StdEncoding.DecodeString(m.Message.Data)
 						assert.NoError(t, err, "message data should be base64 decodable")
 						assert.Equal(t, strconv.Itoa(int(expected)), string(decoded))
-						if counter == 1 {
+						switch counter {
+						case 1:
 							// go fast
 							w.WriteHeader(http.StatusNoContent)
-						} else if counter == 2 {
+						case 2:
 							// delay and nack
 							time.Sleep(50 * time.Millisecond)
 							w.WriteHeader(http.StatusInternalServerError)
-						} else if counter == 3 {
+						case 3:
 							// delay and ack and done
 							time.Sleep(150 * time.Millisecond)
 							w.WriteHeader(http.StatusNoContent)
 							cancel()
-						} else {
+						default:
 							assert.LessOrEqual(t, expected, int32(3))
 							// above will always fail
 							w.WriteHeader(http.StatusInternalServerError)

--- a/services/grpc-subscriber.go
+++ b/services/grpc-subscriber.go
@@ -42,7 +42,6 @@ import (
 	"go.6river.tech/mmmbbb/ent/topic"
 	"go.6river.tech/mmmbbb/filter"
 	"go.6river.tech/mmmbbb/grpc"
-	mbgrpc "go.6river.tech/mmmbbb/grpc"
 	"go.6river.tech/mmmbbb/grpc/pubsubpb"
 	"go.6river.tech/mmmbbb/internal/sqltypes"
 	"go.6river.tech/mmmbbb/logging"
@@ -575,7 +574,7 @@ func (s *subscriberServer) StreamingPull(stream pubsubpb.Subscriber_StreamingPul
 	// we require an initial message before we can start doing anything
 	initial, err := stream.Recv()
 	if err != nil {
-		return mbgrpc.WrapError(err, "Error receiving StreamingPull message")
+		return grpc.WrapError(err, "Error receiving StreamingPull message")
 	}
 
 	if !isValidSubscriptionName(initial.Subscription) {

--- a/services/mirror-common.go
+++ b/services/mirror-common.go
@@ -43,7 +43,7 @@ func parseShardConfig() func(string) bool {
 			panic(err)
 		} else if n != 2 {
 			// should never get here
-			panic(errors.New("Bad format for MIRROR_SHARD_CONFIG"))
+			panic(errors.New("bad format for MIRROR_SHARD_CONFIG"))
 		}
 		// else
 		return func(topicName string) bool {

--- a/services/notifier.go
+++ b/services/notifier.go
@@ -346,7 +346,7 @@ func parseUUIDName(s string) (uuid.UUID, string, error) {
 	// that is the uuid and everything after is the name
 	space := strings.IndexRune(s, ' ')
 	if space < 0 {
-		return uuid.UUID{}, "", errors.New("No space found")
+		return uuid.UUID{}, "", errors.New("no space found")
 	}
 	name := s[space+1:]
 	id, err := uuid.Parse(s[:space])


### PR DESCRIPTION
- **fix: migrate golangci-lint config**
- **fix: updates for new linter errors**
- **fix: enable golines formatter**
- **fix: use golangci-lint fmt for formatting, not full linter run**
- **fix: ensure golangci-lint is v2+ in ci**
